### PR TITLE
transport fixes

### DIFF
--- a/src/message-publisher.ts
+++ b/src/message-publisher.ts
@@ -34,7 +34,7 @@ export class MessagePublisher {
     const payload = new Message(messageName, resolvedMessage.handlerName, message, 'v1');
 
     const defaultTransport = this.moduleConfig.transport;
-    const transport = this.transportResolver.resolve(resolvedMessage.transport || defaultTransport);
+    const transport = this.transportResolver.sender(resolvedMessage.transport || defaultTransport);
 
     await transport.send(payload);
   }

--- a/src/transport.resolver.ts
+++ b/src/transport.resolver.ts
@@ -8,7 +8,7 @@ import { SyncTransport } from './transport/sync';
 export class TransportResolver {
   constructor(private readonly moduleRef: ModuleRef) {}
 
-  resolve(transport: string): ITransport {
+  private resolve(transport: string): ITransport {
     switch (transport) {
       case 'cloud-task':
         return this.moduleRef.get(CloudTaskTransport, { strict: false });
@@ -19,5 +19,13 @@ export class TransportResolver {
       default:
         throw new Error('Un-supported message bus transport');
     }
+  }
+
+  sender(transport: string) {
+    return this.resolve(transport).sender();
+  }
+
+  receiver(transport: string) {
+    return this.resolve(transport).receiver();
   }
 }

--- a/src/transport/cloud-task/cloud-task.module.ts
+++ b/src/transport/cloud-task/cloud-task.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CloudTaskRequest } from './cloud-task.request';
 import { CloudTaskTransport } from './cloud-task.transport';
+import { CloudTaskSender } from './cloud-task.sender';
+import { CloudTaskReceiver } from './cloud-task.receiver';
 
 @Module({
-  providers: [CloudTaskRequest, CloudTaskTransport],
+  providers: [CloudTaskRequest, CloudTaskSender, CloudTaskReceiver, CloudTaskTransport],
   exports: [CloudTaskTransport],
 })
 export class CloudTaskModule {}

--- a/src/transport/cloud-task/cloud-task.receiver.ts
+++ b/src/transport/cloud-task/cloud-task.receiver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { Message } from '../../message';
+import { IReceiver } from '../types';
+import { CloudTaskRequest } from './cloud-task.request';
+
+@Injectable()
+export class CloudTaskReceiver implements IReceiver {
+  constructor(private readonly request: CloudTaskRequest) {}
+
+  async *get() {
+    const body = this.request.getBody();
+    const message = new Message(body.name, body.handler, body.payload, body.version);
+    yield message;
+  }
+}

--- a/src/transport/cloud-task/cloud-task.sender.ts
+++ b/src/transport/cloud-task/cloud-task.sender.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { CloudTasksClient } from '@google-cloud/tasks';
+import { CloudTaskConfig, ModuleConfig } from '../../types';
+import { Message } from '../../message';
+import { MODULE_CONFIG } from '../../constant';
+import { MessageHandlerStore } from '../../message-handler-store';
+import { ISender } from '../types';
+import { CloudTaskRequest } from './cloud-task.request';
+
+@Injectable()
+export class CloudTaskSender implements ISender {
+  private readonly client = new CloudTasksClient();
+  private readonly moduleConfig: ModuleConfig;
+
+  constructor(private readonly moduleRef: ModuleRef, private readonly request: CloudTaskRequest) {
+    this.moduleConfig = this.moduleRef.get(MODULE_CONFIG, { strict: false });
+  }
+
+  async send(message: Message) {
+    const { project, serviceAccountEmail, workerHostUrl, region, defaultQueue } = this.moduleConfig
+      .cloudTask as CloudTaskConfig;
+
+    const handlerConfig = MessageHandlerStore.ofMessageName(message.name);
+    const queue = handlerConfig?.queue || defaultQueue;
+
+    await this.client.createTask({
+      parent: this.client.queuePath(project, region, queue),
+      task: {
+        httpRequest: {
+          httpMethod: 'POST',
+          url: workerHostUrl,
+          body: Buffer.from(JSON.stringify(message)),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          oidcToken: {
+            serviceAccountEmail: serviceAccountEmail,
+          },
+        },
+      },
+    });
+  }
+}

--- a/src/transport/cloud-task/cloud-task.transport.ts
+++ b/src/transport/cloud-task/cloud-task.transport.ts
@@ -1,50 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { CloudTasksClient } from '@google-cloud/tasks';
-import { CloudTaskConfig, ModuleConfig } from '../../types';
-import { Message } from '../../message';
-import { MODULE_CONFIG } from '../../constant';
-import { MessageHandlerStore } from '../../message-handler-store';
 import { ITransport } from '../types';
-import { CloudTaskRequest } from './cloud-task.request';
+import { CloudTaskSender } from './cloud-task.sender';
+import { CloudTaskReceiver } from './cloud-task.receiver';
 
 @Injectable()
 export class CloudTaskTransport implements ITransport {
-  private readonly client = new CloudTasksClient();
-  private readonly moduleConfig: ModuleConfig;
+  constructor(private readonly moduleRef: ModuleRef) {}
 
-  constructor(private readonly moduleRef: ModuleRef, private readonly request: CloudTaskRequest) {
-    this.moduleConfig = this.moduleRef.get(MODULE_CONFIG, { strict: false });
+  sender() {
+    return this.moduleRef.get(CloudTaskSender, { strict: false });
   }
 
-  async send(message: Message) {
-    const { project, serviceAccountEmail, workerHostUrl, region, defaultQueue } = this.moduleConfig
-      .cloudTask as CloudTaskConfig;
-
-    const handlerConfig = MessageHandlerStore.ofMessageName(message.name);
-    const queue = handlerConfig?.queue || defaultQueue;
-
-    await this.client.createTask({
-      parent: this.client.queuePath(project, region, queue),
-      task: {
-        httpRequest: {
-          httpMethod: 'POST',
-          url: workerHostUrl,
-          body: Buffer.from(JSON.stringify(message)),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          oidcToken: {
-            serviceAccountEmail: serviceAccountEmail,
-          },
-        },
-      },
-    });
-  }
-
-  async *get() {
-    const body = this.request.getBody();
-    const message = new Message(body.name, body.handler, body.payload, body.version);
-    yield message;
+  receiver() {
+    return this.moduleRef.get(CloudTaskReceiver, { strict: false });
   }
 }

--- a/src/transport/cloud-task/index.ts
+++ b/src/transport/cloud-task/index.ts
@@ -1,2 +1,4 @@
 export * from './cloud-task.transport';
 export * from './cloud-task.module';
+export * from './cloud-task.sender';
+export * from './cloud-task.receiver';

--- a/src/transport/sync/index.ts
+++ b/src/transport/sync/index.ts
@@ -1,2 +1,4 @@
 export * from './sync-transport';
 export * from './sync.module';
+export * from './sync.receiver';
+export * from './sync.sender';

--- a/src/transport/sync/sync-transport.ts
+++ b/src/transport/sync/sync-transport.ts
@@ -1,17 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { ITransport } from '../types';
-import { Message } from '../../message';
-import { Dispatcher } from '../../dispatcher';
+import { SyncSender } from './sync.sender';
+import { SyncReceiver } from './sync.receiver';
 
 @Injectable()
 export class SyncTransport implements ITransport {
-  constructor(private readonly dispatcher: Dispatcher) {}
+  constructor(private readonly moduleRef: ModuleRef) {}
 
-  async send(message: Message) {
-    return this.dispatcher.dispatchNow(message);
+  sender() {
+    return this.moduleRef.get(SyncSender, { strict: false });
   }
 
-  async *get() {
-    throw new Error('Sync transport does not support receiving messages');
+  receiver() {
+    return this.moduleRef.get(SyncReceiver, { strict: false });
   }
 }

--- a/src/transport/sync/sync.module.ts
+++ b/src/transport/sync/sync.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { Dispatcher } from '../../dispatcher';
 import { SyncTransport } from './sync-transport';
+import { SyncSender } from './sync.sender';
+import { SyncReceiver } from './sync.receiver';
 
 @Module({
-  providers: [SyncTransport, Dispatcher],
+  providers: [SyncTransport, SyncSender, SyncReceiver, Dispatcher],
   exports: [SyncTransport],
 })
 export class SyncModule {}

--- a/src/transport/sync/sync.receiver.ts
+++ b/src/transport/sync/sync.receiver.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { IReceiver } from '../types';
+
+@Injectable()
+export class SyncReceiver implements IReceiver {
+  async *get() {
+    throw new Error('Sync transport cannot listen to messages');
+  }
+}

--- a/src/transport/sync/sync.sender.ts
+++ b/src/transport/sync/sync.sender.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { Dispatcher } from '../../dispatcher';
+import { ISender } from '../types';
+import { Message } from '../../message';
+
+@Injectable()
+export class SyncSender implements ISender {
+  constructor(private readonly dispatcher: Dispatcher) {}
+
+  async send(message: Message) {
+    return this.dispatcher.dispatchNow(message);
+  }
+}

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,6 +1,14 @@
 import { Message } from 'message';
 
-export interface ITransport {
+export interface ISender {
   readonly send: (message: Message) => Promise<void>;
+}
+
+export interface IReceiver {
   readonly get: () => AsyncGenerator<Message>;
+}
+
+export interface ITransport {
+  readonly sender: () => ISender;
+  readonly receiver: () => IReceiver;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,9 +10,9 @@ export class Worker {
   ) {}
 
   async run(transport: string) {
-    const resolvedTransport = this.transportResolver.resolve(transport);
+    const resolvedReceiver = this.transportResolver.receiver(transport);
 
-    for await (const message of resolvedTransport.get()) {
+    for await (const message of resolvedReceiver.get()) {
       await this.dispatcher.dispatchNow(message);
     }
   }

--- a/test/unit/message-bus.spec.ts
+++ b/test/unit/message-bus.spec.ts
@@ -5,8 +5,8 @@ import { IMessage, IMessageHandler } from '../../src/interfaces';
 import { MessageHandler } from '../../src/decorator';
 import { MessageBus } from '../../src/message-bus';
 import { Message } from '../../src/message';
-import { CloudTaskTransport } from '../../src/transport/cloud-task';
-import { SyncTransport } from '../../src/transport/sync';
+import { CloudTaskSender } from '../../src/transport/cloud-task';
+import { SyncSender } from '../../src/transport/sync';
 import { MessageBusModule } from '../../src/message-bus.module';
 
 describe('Message Bus', () => {
@@ -121,7 +121,7 @@ describe('Message Bus', () => {
     }).compile();
 
     const messageBus = app.get<MessageBus>(MessageBus);
-    const transport = app.get(CloudTaskTransport);
+    const transport = app.get(CloudTaskSender);
 
     transport.send = jest.fn();
 
@@ -159,7 +159,7 @@ describe('Message Bus', () => {
     }).compile();
 
     const messageBus = app.get<MessageBus>(MessageBus);
-    const transport = app.get(SyncTransport);
+    const transport = app.get(SyncSender);
 
     transport.send = jest.fn();
 


### PR DESCRIPTION
This pr separates `sender` and `receiver` for sync and cloud-task transport